### PR TITLE
Enable direct navigation to routes in SPA when using webpack-dev-server.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dolittle/build.aurelia",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "Build pipeline for Aurelia based JavaScript applications",
   "main": "index.js",
   "scripts": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -58,6 +58,10 @@ module.exports = ({ production, server, extractCss, coverage, analyze } = {}) =>
     mode: production ? 'production' : 'development',
     devtool: production ? 'nosources-source-map' : 'cheap-module-eval-source-map',
 
+    devServer: {
+        historyApiFallback: true
+    },
+
     output: {
         path: outDir,
         publicPath: baseUrl,


### PR DESCRIPTION
The webpack config change tells the webpack-dev-server to serve index.html whenever a request would normally result in 404.
This enables direct navigation in the browser to routes defined in the Aurelia Router when .pushState = true (i.e. when the history api is used).