### PR TITLE
Allow cleaning of external outDir's by setting the outDir as rootAs a CLI agent user, I would like to see details from a node

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -136,7 +136,7 @@ module.exports = ({ production, server, extractCss, analyze } = {}) => ({
     },
 
     plugins: [
-        new CleanWebpackPlugin([`${outDir}/**/*.*`], { root: rootDir }),
+        new CleanWebpackPlugin([`${outDir}/**/*.*`], { root: outDir }),
         new WatchIgnorePlugin(['**/for_*/*.js', '**/when_*/*.js', '**/specs/*.js']),
         new AureliaPlugin(),
         new ProvidePlugin({


### PR DESCRIPTION
I think that this will resolve issue #21. (Asana: [CleanWebpackPlugin doesn't clean the output dir when it's outside the root dir](https://app.asana.com/0/0/1126599662138492))



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1115616103797671/1126600827255571)
